### PR TITLE
empty OTEL_EXPORTER_OTLP_INSECURE should not log

### DIFF
--- a/otelinit/config.go
+++ b/otelinit/config.go
@@ -19,10 +19,17 @@ func newConfig(serviceName string) config {
 	// Use stdlib to parse. If it's an invalid value and doesn't parse, log it
 	// and keep going. It should already be false on error but we force it to
 	// be extra clear that it's failing closed.
-	insecure, err := strconv.ParseBool(os.Getenv("OTEL_EXPORTER_OTLP_INSECURE"))
-	if err != nil {
+	isEnv := os.Getenv("OTEL_EXPORTER_OTLP_INSECURE")
+	var insecure bool
+	if isEnv != "" {
+		var err error
+		insecure, err = strconv.ParseBool(isEnv)
+		if err != nil {
+			insecure = false
+			log.Println("Invalid boolean value in OTEL_EXPORTER_OTLP_INSECURE. Try true or false.")
+		}
+	} else {
 		insecure = false
-		log.Println("Invalid boolean value in OTEL_EXPORTER_OTLP_INSECURE. Try true or false.")
 	}
 
 	return config{


### PR DESCRIPTION
Turns out strconv.ParseBool returns error on empty string, so this avoids that while keeping it clear how it fails closed.