### PR TITLE
Add renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ]
+}


### PR DESCRIPTION
Renovate should start managing PRs to update our dependencies.
Some upstream libraries are releasing new versions and I think keeping otel-init-go up to date will help us stay compatible with those new versions.